### PR TITLE
Re-categorizing CoEpi

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -372,7 +372,16 @@ landscape:
             homepage_url: 'https://www.coalitionnetwork.org/'
             logo: coalition.svg
             crunchbase: 'https://www.crunchbase.com/organization/coalition-network'
-          - item:
+         - item:
+            name: CoEpi
+            description: 'CoEpi is a privacy-first system for anonymous Bluetooth proximity-based exposure alerting based on voluntary symptom sharing.'
+            homepage_url: 'https://www.coepi.org'
+            repo_url: 'https://github.com/Co-Epi/app-android'
+            additional_repos:
+              - repo_url: 'https://github.com/Co-Epi/app-ios'
+            logo: coepi.svg
+            crunchbase: 'https://www.crunchbase.com/organization/coepi'
+         - item:
             name: CommonCircle
             homepage_url: 'https://commoncircle.us/'
             repo_url: 'https://github.com/covidsafe/App-Android'
@@ -563,15 +572,6 @@ landscape:
       - subcategory:
         name: App
         items:
-          - item:
-            name: CoEpi
-            description: CoEpi is a privacy-first system for anonymous Bluetooth proximity-based exposure alerting based on voluntary symptom sharing.
-            homepage_url: 'https://www.coepi.org'
-            repo_url: 'https://github.com/Co-Epi/app-android'
-            additional_repos:
-              - repo_url: 'https://github.com/Co-Epi/app-ios'
-            logo: coepi.svg
-            crunchbase: 'https://www.crunchbase.com/organization/coepi'
           - item:
             name: How We Feel
             homepage_url: 'https://howwefeel.org/'

--- a/landscape.yml
+++ b/landscape.yml
@@ -372,7 +372,7 @@ landscape:
             homepage_url: 'https://www.coalitionnetwork.org/'
             logo: coalition.svg
             crunchbase: 'https://www.crunchbase.com/organization/coalition-network'
-         - item:
+          - item:
             name: CoEpi
             description: 'CoEpi is a privacy-first system for anonymous Bluetooth proximity-based exposure alerting based on voluntary symptom sharing.'
             homepage_url: 'https://www.coepi.org'
@@ -381,7 +381,7 @@ landscape:
               - repo_url: 'https://github.com/Co-Epi/app-ios'
             logo: coepi.svg
             crunchbase: 'https://www.crunchbase.com/organization/coepi'
-         - item:
+          - item:
             name: CommonCircle
             homepage_url: 'https://commoncircle.us/'
             repo_url: 'https://github.com/covidsafe/App-Android'


### PR DESCRIPTION
CoEpi was previously listed under symptom 'monitoring', when it is an exposure notification app that notifies based on symptom sharing using a non-GAEN (TCN) protocol.
